### PR TITLE
[FIX] AWS lambda example: save & load `BOT_TOKEN` from `.env`

### DIFF
--- a/examples/functions/aws-lambda/.env.example
+++ b/examples/functions/aws-lambda/.env.example
@@ -1,0 +1,1 @@
+BOT_TOKEN="1234567890:AABBCCDDeeffgghhiijjllaskdjflasddsl"

--- a/examples/functions/aws-lambda/.gitignore
+++ b/examples/functions/aws-lambda/.gitignore
@@ -6,3 +6,6 @@ node_modules
 
 # compiled JS if any
 echo.js
+
+# secrets
+.env

--- a/examples/functions/aws-lambda/README.md
+++ b/examples/functions/aws-lambda/README.md
@@ -13,11 +13,18 @@ npm run purge
 npm run set-webhook
 ```
 
-After running `npm run release`, you must copy the full URL it prints and run:
+Copy `.env.example` to `.env` and replace the `BOT_TOKEN` with the one you've received from the Telegram Botfather.
+
+After running `npm run release` your code is deployed at AWS and you should be able to see it in the console.
+
+The next step is to tell the [Telegram Bot API your endpoint](https://core.telegram.org/bots/api#setwebhook).
+To use the Telegraf helper function, you must copy the full URL from the deployment step and run:
 
 ```shell
 npm run set-webhook -- -t $BOT_TOKEN -D '{ "url": $FULL_URL_TO_FUNCTION }'
 ```
+
+(an alternative method to set the webhook using cURL can be found [here](https://github.com/serverless/examples/tree/v3/aws-node-telegram-echo-bot))
 
 If you publish to AWS Lambda with a CI, you can run this npm script from your CI instead.
 

--- a/examples/functions/aws-lambda/package-lock.json
+++ b/examples/functions/aws-lambda/package-lock.json
@@ -9,10 +9,11 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"serverless-http": "^3.0.2",
-				"telegraf": "^4.8.0"
+				"telegraf": "^4.9.0"
 			},
 			"devDependencies": {
 				"serverless": "^3.22.0",
+				"serverless-dotenv-plugin": "^4.0.2",
 				"serverless-plugin-typescript": "^2.1.2",
 				"typescript": "^4.7.4"
 			}
@@ -3330,11 +3331,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-		},
 		"node_modules/minipass": {
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
@@ -3372,10 +3368,13 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/module-alias": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-			"integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
+		"node_modules/mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
@@ -4233,6 +4232,38 @@
 				"node": ">=12.0"
 			}
 		},
+		"node_modules/serverless-dotenv-plugin": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-4.0.2.tgz",
+			"integrity": "sha512-MOXsSSuJPMAiNp7bVvvCC+ahmEMMohlaPpaVU2w4wFgMVSvs+BU7xIwQGv/7TTMNdjYVS/W2JoS5ZSkCdjHzCg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"dotenv": "^16.0.1",
+				"dotenv-expand": "^8.0.3"
+			},
+			"peerDependencies": {
+				"serverless": "1 || 2 || pre-3 || 3"
+			}
+		},
+		"node_modules/serverless-dotenv-plugin/node_modules/dotenv": {
+			"version": "16.0.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+			"integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/serverless-dotenv-plugin/node_modules/dotenv-expand": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-8.0.3.tgz",
+			"integrity": "sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/serverless-http": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.0.2.tgz",
@@ -4613,22 +4644,21 @@
 			}
 		},
 		"node_modules/telegraf": {
-			"version": "4.8.6",
-			"resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.8.6.tgz",
-			"integrity": "sha512-FixxnJBrS8ECk/Wmo3VXzkTOlY2A1gsdIORJ//cdh3PcVqAL7wgcvLKjkEPI0IyxdFfRqTrWQEOn9h++revQaA==",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.9.2.tgz",
+			"integrity": "sha512-NONBwsIWAX4d6kq81IhvA9mfCe9RlElGmDTryKXRDSQ1r1u1ZPgTTeBfzOvzKF4Uc/f3AcH746wj2dIjAVt4HA==",
 			"dependencies": {
 				"abort-controller": "^3.0.0",
 				"debug": "^4.3.3",
-				"minimist": "^1.2.6",
-				"module-alias": "^2.2.2",
+				"mri": "^1.2.0",
 				"node-fetch": "^2.6.7",
 				"p-timeout": "^4.1.0",
 				"safe-compare": "^1.1.4",
 				"sandwich-stream": "^2.0.2",
-				"typegram": "^3.9.0"
+				"typegram": "^3.11.0"
 			},
 			"bin": {
-				"telegraf": "bin/telegraf"
+				"telegraf": "lib/cli.mjs"
 			},
 			"engines": {
 				"node": "^12.20.0 || >=14.13.1"
@@ -4779,9 +4809,9 @@
 			}
 		},
 		"node_modules/typegram": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/typegram/-/typegram-3.10.0.tgz",
-			"integrity": "sha512-kma7ZF7SFRqcUCgo5sHg1MbPwc9/KYjVkbvrqIZK7oXfPdLBGz1s7wF9d7o4yjHp+AOGke8cyYGhI/+4xYYC4Q=="
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/typegram/-/typegram-3.12.0.tgz",
+			"integrity": "sha512-/VrU0sJv8BdOsBIpYT4w35C7dPg5YyKP6fLiYN9qYXRZ86TVIiw0ZypkzElTAfDVsJtJSluGAufUrcX7VRSIYQ=="
 		},
 		"node_modules/typescript": {
 			"version": "4.7.4",
@@ -7768,11 +7798,6 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
-		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-		},
 		"minipass": {
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
@@ -7798,10 +7823,10 @@
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true
 		},
-		"module-alias": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-			"integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
+		"mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
 		},
 		"ms": {
 			"version": "2.1.2",
@@ -8412,6 +8437,31 @@
 				"yaml-ast-parser": "0.0.43"
 			}
 		},
+		"serverless-dotenv-plugin": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-4.0.2.tgz",
+			"integrity": "sha512-MOXsSSuJPMAiNp7bVvvCC+ahmEMMohlaPpaVU2w4wFgMVSvs+BU7xIwQGv/7TTMNdjYVS/W2JoS5ZSkCdjHzCg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.2",
+				"dotenv": "^16.0.1",
+				"dotenv-expand": "^8.0.3"
+			},
+			"dependencies": {
+				"dotenv": {
+					"version": "16.0.2",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+					"integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+					"dev": true
+				},
+				"dotenv-expand": {
+					"version": "8.0.3",
+					"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-8.0.3.tgz",
+					"integrity": "sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==",
+					"dev": true
+				}
+			}
+		},
 		"serverless-http": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.0.2.tgz",
@@ -8715,19 +8765,18 @@
 			}
 		},
 		"telegraf": {
-			"version": "4.8.6",
-			"resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.8.6.tgz",
-			"integrity": "sha512-FixxnJBrS8ECk/Wmo3VXzkTOlY2A1gsdIORJ//cdh3PcVqAL7wgcvLKjkEPI0IyxdFfRqTrWQEOn9h++revQaA==",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.9.2.tgz",
+			"integrity": "sha512-NONBwsIWAX4d6kq81IhvA9mfCe9RlElGmDTryKXRDSQ1r1u1ZPgTTeBfzOvzKF4Uc/f3AcH746wj2dIjAVt4HA==",
 			"requires": {
 				"abort-controller": "^3.0.0",
 				"debug": "^4.3.3",
-				"minimist": "^1.2.6",
-				"module-alias": "^2.2.2",
+				"mri": "^1.2.0",
 				"node-fetch": "^2.6.7",
 				"p-timeout": "^4.1.0",
 				"safe-compare": "^1.1.4",
 				"sandwich-stream": "^2.0.2",
-				"typegram": "^3.9.0"
+				"typegram": "^3.11.0"
 			},
 			"dependencies": {
 				"p-timeout": {
@@ -8840,9 +8889,9 @@
 			"dev": true
 		},
 		"typegram": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/typegram/-/typegram-3.10.0.tgz",
-			"integrity": "sha512-kma7ZF7SFRqcUCgo5sHg1MbPwc9/KYjVkbvrqIZK7oXfPdLBGz1s7wF9d7o4yjHp+AOGke8cyYGhI/+4xYYC4Q=="
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/typegram/-/typegram-3.12.0.tgz",
+			"integrity": "sha512-/VrU0sJv8BdOsBIpYT4w35C7dPg5YyKP6fLiYN9qYXRZ86TVIiw0ZypkzElTAfDVsJtJSluGAufUrcX7VRSIYQ=="
 		},
 		"typescript": {
 			"version": "4.7.4",

--- a/examples/functions/aws-lambda/package.json
+++ b/examples/functions/aws-lambda/package.json
@@ -16,6 +16,7 @@
 	},
 	"devDependencies": {
 		"serverless": "^3.22.0",
+		"serverless-dotenv-plugin": "^4.0.2",
 		"serverless-plugin-typescript": "^2.1.2",
 		"typescript": "^4.7.4"
 	}

--- a/examples/functions/aws-lambda/serverless.yaml
+++ b/examples/functions/aws-lambda/serverless.yaml
@@ -2,6 +2,8 @@
 	service: "aws",
 	frameworkVersion: "3",
 
+	useDotenv: true,
+
 	package: {
 		excludeDevDependencies: true,
 	},
@@ -12,7 +14,8 @@
 	},
 
 	plugins: [
-		"serverless-plugin-typescript"
+		"serverless-plugin-typescript",
+		"serverless-dotenv-plugin"
 	],
 
 	functions: {


### PR DESCRIPTION
Fixes #2:

- Improve AWS lambda example by adding a secret `.env`
- Extend `README`