### PR TITLE
Update fastify.ts example

### DIFF
--- a/examples/webhook/fastify.ts
+++ b/examples/webhook/fastify.ts
@@ -6,7 +6,7 @@ const app = fastify();
 
 const webhook = await bot.createWebhook({ domain: webhookDomain });
 
-app.post(bot.secretPathComponent(), (req, rep) => webhook(req.raw, rep.raw));
+app.post(`/telegraf/${bot.secretPathComponent()}`, webhook);
 
 bot.on("text", ctx => ctx.reply("Hello"));
 


### PR DESCRIPTION
There was an error in the previous example as it would not be using the path that is created by `bot.createWebhook`. Also the way the callback was being used was incorrect and would cause a Fastify 415 error for incorrect response type.