### PR TITLE
[codex] Sync docs for Telegraf v6 networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ PORT=3000
 WEBHOOK_DOMAIN=bot.example.com
 BOT_TOKEN=123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
 ```
+
+### Runtime networking and proxies
+
+Telegraf v6 uses the Node.js native `globalThis.fetch` implementation by default. It no longer exposes the old `telegram.agent` or `telegram.attachmentAgent` options.
+
+If your bot needs a proxy, custom TLS handling, custom compression, or another non-standard network path, install the fetch and agent packages you need and inject that behavior with `telegram.fetch`. The custom fetch is used for both Bot API calls and URL attachments. See [`examples/proxy-bot.ts`](./examples/proxy-bot.ts) for a proxy example.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This repo will house the future of Telegraf's documentation. For now, it houses 
 
 ### [![New](https://img.shields.io/badge/new%20✨-8A2BE2?style=flat-square) Build Telegram Mini Apps with Telegraf](./examples/mini-apps/README.md)
 
+## Development
+
+Use pnpm for the repo-level examples and typecheck:
+
+```shell
+npx --yes pnpm@8.15.9 install --frozen-lockfile
+npx --yes pnpm@8.15.9 build
+```
+
+Standalone deployment templates may use their platform's package manager. For example, the AWS Lambda example keeps its own npm lockfile.
+
 ## How to use these examples:
 
 In the interest of brevity, the examples in the repo don't explain certain good-to-haves.

--- a/examples/custom-context-bot.ts
+++ b/examples/custom-context-bot.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { Context, Telegraf, Telegram } from 'telegraf'
-import { Update, UserFromGetMe } from 'typegram'
+import { Update, UserFromGetMe } from 'telegraf/types'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {

--- a/examples/download-bot.ts
+++ b/examples/download-bot.ts
@@ -16,7 +16,9 @@ const bot = new Telegraf(process.env.BOT_TOKEN);
 const download = async (fromFileId: string, toPath: string) => {
 	const link = await bot.telegram.getFileLink(fromFileId);
 	const res = await fetch(link.toString());
-	await res.body!.pipeTo(Writable.toWeb(createWriteStream(toPath)));
+	await res.body!.pipeTo(
+		Writable.toWeb(createWriteStream(toPath)) as WritableStream<Uint8Array>,
+	);
 };
 
 // handler that downloads all photos the bot sees to a photos

--- a/examples/functions/aws-lambda/README.md
+++ b/examples/functions/aws-lambda/README.md
@@ -2,6 +2,8 @@
 
 This template demonstrates how to run a simple Telegraf echo bot with on AWS Lambda and API Gateway using the Serverless Framework.
 
+Telegraf v6 requires Node.js 20 or newer, so the Serverless example uses the AWS Lambda `nodejs20.x` runtime.
+
 ## Usage
 
 After installing dependencies (using `npm install` or the similar), the following commands are available:

--- a/examples/functions/aws-lambda/package-lock.json
+++ b/examples/functions/aws-lambda/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"serverless-http": "^3.1.1",
-				"telegraf": "git+https://github.com/Leask/telegraf.git#bot-api-9.6-sync"
+				"telegraf": "npm:@leask/telegraf@6.0.0"
 			},
 			"devDependencies": {
 				"@types/node": "^20.19.39",
@@ -281,8 +281,10 @@
 			}
 		},
 		"node_modules/@telegraf/types": {
+			"name": "@leask/types",
 			"version": "9.6.0",
-			"resolved": "git+https://github.com/Leask/types.git#012947771d009d7ab1233dd96d95683d74471cf5",
+			"resolved": "https://registry.npmjs.org/@leask/types/-/types-9.6.0.tgz",
+			"integrity": "sha512-rCIH++ksNWJZ4JZ3j3aQ49xRDjMJlCTz64bQY4YzVunGgsI+jSBitXv751f2bz5Kqf2xgHlGCu+LXLvposGpYw==",
 			"license": "MIT"
 		},
 		"node_modules/@tokenizer/token": {
@@ -4343,11 +4345,13 @@
 			}
 		},
 		"node_modules/telegraf": {
+			"name": "@leask/telegraf",
 			"version": "6.0.0",
-			"resolved": "git+https://github.com/Leask/telegraf.git#07a9ef325efb1a53fb196de80ce8b817c1149b1e",
+			"resolved": "https://registry.npmjs.org/@leask/telegraf/-/telegraf-6.0.0.tgz",
+			"integrity": "sha512-3scLSWBf1rJsEvBNvpSI0JfVLZfHzEDEFu8L4g/oRt8XCTiasf/4Bgi0C32+JbOV8Akdk5oe/xufAFG+fviqtw==",
 			"license": "MIT",
 			"dependencies": {
-				"@telegraf/types": "git+https://github.com/Leask/types.git#bot-api-9.6-sync",
+				"@telegraf/types": "npm:@leask/types@9.6.0",
 				"debug": "^4.4.3",
 				"mri": "^1.2.0",
 				"p-timeout": "^7.0.1",

--- a/examples/functions/aws-lambda/package-lock.json
+++ b/examples/functions/aws-lambda/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"serverless-http": "^3.1.1",
-				"telegraf": "npm:@leask/telegraf@6.0.0"
+				"telegraf": "npm:@leask/telegraf@6.0.1"
 			},
 			"devDependencies": {
 				"@types/node": "^20.19.39",
@@ -4346,9 +4346,9 @@
 		},
 		"node_modules/telegraf": {
 			"name": "@leask/telegraf",
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@leask/telegraf/-/telegraf-6.0.0.tgz",
-			"integrity": "sha512-3scLSWBf1rJsEvBNvpSI0JfVLZfHzEDEFu8L4g/oRt8XCTiasf/4Bgi0C32+JbOV8Akdk5oe/xufAFG+fviqtw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@leask/telegraf/-/telegraf-6.0.1.tgz",
+			"integrity": "sha512-loLp4S/FbfRxzpw6leVJZwJUm06af2PXpMaV0+oJkCFuMlU2+h4jRlnmLIDsVJy2FO16E9IKqGl8DTXJfQDpkQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@telegraf/types": "npm:@leask/types@9.6.0",

--- a/examples/functions/aws-lambda/package-lock.json
+++ b/examples/functions/aws-lambda/package-lock.json
@@ -9,13 +9,14 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"serverless-http": "^3.1.1",
-				"telegraf": "^4.11.2"
+				"telegraf": "github:Leask/telegraf#bot-api-9.6-sync"
 			},
 			"devDependencies": {
+				"@types/node": "^20.19.39",
 				"serverless": "^3.28.1",
 				"serverless-dotenv-plugin": "^4.0.2",
 				"serverless-plugin-typescript": "^2.1.4",
-				"typescript": "^4.9.5"
+				"typescript": "^5.2.2"
 			}
 		},
 		"node_modules/@kwsites/file-exists": {
@@ -279,6 +280,11 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@telegraf/types": {
+			"version": "9.6.0",
+			"resolved": "git+ssh://git@github.com/Leask/types.git#012947771d009d7ab1233dd96d95683d74471cf5",
+			"license": "MIT"
+		},
 		"node_modules/@tokenizer/token": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -335,10 +341,14 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.14.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-			"integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
-			"dev": true
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
 		},
 		"node_modules/@types/responselike": {
 			"version": "1.0.0",
@@ -357,17 +367,6 @@
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "^0.10.47"
-			}
-		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
 			}
 		},
 		"node_modules/adm-zip": {
@@ -1273,11 +1272,12 @@
 			"dev": true
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -1752,14 +1752,6 @@
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
-			}
-		},
-		"node_modules/event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/events": {
@@ -3162,9 +3154,10 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
 		},
 		"node_modules/mute-stream": {
 			"version": "0.0.8",
@@ -3222,6 +3215,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
 			"integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+			"dev": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -4349,32 +4343,34 @@
 			}
 		},
 		"node_modules/telegraf": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.11.2.tgz",
-			"integrity": "sha512-RGEh+NXkHbq1KcSSbJeVYhHMrEN4rymd9DSe3SoIV0886bJPBHLzYCNrOqnk9aeZE2Idwh5uK0X/xbR6jScQKQ==",
+			"version": "6.0.0",
+			"resolved": "git+ssh://git@github.com/Leask/telegraf.git#07a9ef325efb1a53fb196de80ce8b817c1149b1e",
+			"license": "MIT",
 			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"debug": "^4.3.4",
+				"@telegraf/types": "git+https://github.com/Leask/types.git#bot-api-9.6-sync",
+				"debug": "^4.4.3",
 				"mri": "^1.2.0",
-				"node-fetch": "^2.6.7",
-				"p-timeout": "^4.1.0",
+				"p-timeout": "^7.0.1",
 				"safe-compare": "^1.1.4",
-				"sandwich-stream": "^2.0.2",
-				"typegram": "^4.1.0"
+				"sandwich-stream": "^2.0.2"
 			},
 			"bin": {
 				"telegraf": "lib/cli.mjs"
 			},
 			"engines": {
-				"node": "^12.20.0 || >=14.13.1"
+				"node": ">=20"
 			}
 		},
 		"node_modules/telegraf/node_modules/p-timeout": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-			"integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=10"
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/throat": {
@@ -4469,7 +4465,8 @@
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
 		},
 		"node_modules/traverse": {
 			"version": "0.6.7",
@@ -4516,22 +4513,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/typegram": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/typegram/-/typegram-4.3.0.tgz",
-			"integrity": "sha512-pS4STyOZoJ++Mwa9GPMTNjOwEzMkxFfFt1By6IbMOJfheP0utMP/H1ga6J9R4DTjAYBr0UDn4eQg++LpWBvcAg=="
-		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/unbzip2-stream": {
@@ -4567,6 +4560,13 @@
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/uni-global": {
 			"version": "1.0.0",
@@ -4679,12 +4679,14 @@
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"

--- a/examples/functions/aws-lambda/package-lock.json
+++ b/examples/functions/aws-lambda/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"serverless-http": "^3.1.1",
-				"telegraf": "github:Leask/telegraf#bot-api-9.6-sync"
+				"telegraf": "git+https://github.com/Leask/telegraf.git#bot-api-9.6-sync"
 			},
 			"devDependencies": {
 				"@types/node": "^20.19.39",
@@ -282,7 +282,7 @@
 		},
 		"node_modules/@telegraf/types": {
 			"version": "9.6.0",
-			"resolved": "git+ssh://git@github.com/Leask/types.git#012947771d009d7ab1233dd96d95683d74471cf5",
+			"resolved": "git+https://github.com/Leask/types.git#012947771d009d7ab1233dd96d95683d74471cf5",
 			"license": "MIT"
 		},
 		"node_modules/@tokenizer/token": {
@@ -4344,7 +4344,7 @@
 		},
 		"node_modules/telegraf": {
 			"version": "6.0.0",
-			"resolved": "git+ssh://git@github.com/Leask/telegraf.git#07a9ef325efb1a53fb196de80ce8b817c1149b1e",
+			"resolved": "git+https://github.com/Leask/telegraf.git#07a9ef325efb1a53fb196de80ce8b817c1149b1e",
 			"license": "MIT",
 			"dependencies": {
 				"@telegraf/types": "git+https://github.com/Leask/types.git#bot-api-9.6-sync",

--- a/examples/functions/aws-lambda/package.json
+++ b/examples/functions/aws-lambda/package.json
@@ -12,7 +12,10 @@
 	},
 	"dependencies": {
 		"serverless-http": "^3.1.1",
-		"telegraf": "github:Leask/telegraf#bot-api-9.6-sync"
+		"telegraf": "git+https://github.com/Leask/telegraf.git#bot-api-9.6-sync"
+	},
+	"overrides": {
+		"@telegraf/types": "git+https://github.com/Leask/types.git#bot-api-9.6-sync"
 	},
 	"devDependencies": {
 		"@types/node": "^20.19.39",

--- a/examples/functions/aws-lambda/package.json
+++ b/examples/functions/aws-lambda/package.json
@@ -12,12 +12,13 @@
 	},
 	"dependencies": {
 		"serverless-http": "^3.1.1",
-		"telegraf": "^4.11.2"
+		"telegraf": "github:Leask/telegraf#bot-api-9.6-sync"
 	},
 	"devDependencies": {
+		"@types/node": "^20.19.39",
 		"serverless": "^3.28.1",
 		"serverless-dotenv-plugin": "^4.0.2",
 		"serverless-plugin-typescript": "^2.1.4",
-		"typescript": "^4.9.5"
+		"typescript": "^5.2.2"
 	}
 }

--- a/examples/functions/aws-lambda/package.json
+++ b/examples/functions/aws-lambda/package.json
@@ -12,10 +12,7 @@
 	},
 	"dependencies": {
 		"serverless-http": "^3.1.1",
-		"telegraf": "git+https://github.com/Leask/telegraf.git#bot-api-9.6-sync"
-	},
-	"overrides": {
-		"@telegraf/types": "git+https://github.com/Leask/types.git#bot-api-9.6-sync"
+		"telegraf": "npm:@leask/telegraf@6.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^20.19.39",

--- a/examples/functions/aws-lambda/package.json
+++ b/examples/functions/aws-lambda/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"serverless-http": "^3.1.1",
-		"telegraf": "npm:@leask/telegraf@6.0.0"
+		"telegraf": "npm:@leask/telegraf@6.0.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20.19.39",

--- a/examples/functions/aws-lambda/serverless.yaml
+++ b/examples/functions/aws-lambda/serverless.yaml
@@ -10,7 +10,7 @@
 
 	provider: {
 		name: "aws",
-		runtime: "nodejs16.x",
+		runtime: "nodejs20.x",
 	},
 
 	plugins: [

--- a/examples/functions/aws-lambda/tsconfig.json
+++ b/examples/functions/aws-lambda/tsconfig.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
 		"strict": true,
 		"module": "NodeNext",
-		"target": "es2021"
+		"target": "es2023",
+		"types": ["node"]
 	},
 	"include": ["echo.ts"]
 }

--- a/examples/inline-bot.ts
+++ b/examples/inline-bot.ts
@@ -17,7 +17,7 @@ bot.on("inline_query", async ctx => {
 				id: thumbnail,
 				title: title,
 				description: title,
-				thumb_url: thumbnail,
+				thumbnail_url: thumbnail,
 				input_message_content: {
 					message_text: title,
 				},

--- a/examples/poll-bot.ts
+++ b/examples/poll-bot.ts
@@ -18,7 +18,7 @@ bot.command("poll", ctx =>
 	}),
 );
 bot.command("quiz", ctx =>
-	ctx.replyWithQuiz("2b|!2b", ["True", "False"], { correct_option_id: 0 }),
+	ctx.replyWithQuiz("2b|!2b", ["True", "False"], { correct_option_ids: [0] }),
 );
 
 bot.launch();

--- a/examples/proxy-bot.ts
+++ b/examples/proxy-bot.ts
@@ -1,17 +1,25 @@
 import { Telegraf } from "telegraf";
+import fetch from "node-fetch";
 import { HttpsProxyAgent } from "https-proxy-agent";
 
-const { HTTPS_PROXY_HOST, HTTPS_PROXY_PORT } = process.env;
+const { BOT_TOKEN, HTTPS_PROXY } = process.env;
 
-const agent = new HttpsProxyAgent({
-	host: HTTPS_PROXY_HOST,
-	port: HTTPS_PROXY_PORT,
+if (!BOT_TOKEN) throw new Error('"BOT_TOKEN" env var is required!');
+if (!HTTPS_PROXY) throw new Error('"HTTPS_PROXY" env var is required!');
+
+const agent = new HttpsProxyAgent(HTTPS_PROXY);
+
+const fetchWithProxy = (url: URL | string, init?: RequestInit) =>
+	fetch(
+		String(url),
+		{ ...init, agent } as unknown as Parameters<typeof fetch>[1],
+	);
+
+const bot = new Telegraf(BOT_TOKEN, {
+	telegram: { fetch: fetchWithProxy },
 });
 
-const bot = new Telegraf(token, { telegram: { agent } });
-
-// If you want to use agent for fetching files, as well, use:
-// const bot = new Telegraf(BOT_TOKEN, { telegram: { agent, attachmentAgent: agent } })
+// The custom fetch is used for Bot API calls and URL attachments.
 
 bot.start(ctx => ctx.reply("Hello"));
 bot.help(ctx => ctx.reply("Help message"));

--- a/examples/webhook/fastify.ts
+++ b/examples/webhook/fastify.ts
@@ -1,14 +1,17 @@
 import { fastify } from "fastify";
 import { Telegraf } from "telegraf";
+import type { Update } from "telegraf/types";
 
 const bot = new Telegraf(token);
 const app = fastify();
 
-const webhook = await bot.createWebhook({ domain: webhookDomain });
+const webhookPath = `/telegraf/${bot.secretPathComponent()}`;
+await bot.createWebhook({ domain: webhookDomain, path: webhookPath });
 
-app.post(`/telegraf/${bot.secretPathComponent()}`, (request, reply) =>
-	webhook(request.raw, reply.raw),
-);
+app.post(webhookPath, async (request, reply) => {
+	await bot.handleUpdate(request.body as Update);
+	return reply.code(200).send();
+});
 
 bot.on("text", ctx => ctx.reply("Hello"));
 

--- a/examples/webhook/fastify.ts
+++ b/examples/webhook/fastify.ts
@@ -6,7 +6,9 @@ const app = fastify();
 
 const webhook = await bot.createWebhook({ domain: webhookDomain });
 
-app.post(`/telegraf/${bot.secretPathComponent()}`, webhook);
+app.post(`/telegraf/${bot.secretPathComponent()}`, (request, reply) =>
+	webhook(request.raw, reply.raw),
+);
 
 bot.on("text", ctx => ctx.reply("Hello"));
 

--- a/examples/webhook/koa.ts
+++ b/examples/webhook/koa.ts
@@ -1,6 +1,6 @@
 import { Telegraf } from "telegraf";
 import Koa from "koa";
-import koaBody from "koa-body";
+import { koaBody } from "koa-body";
 
 const bot = new Telegraf(token);
 const app = new Koa();

--- a/guide/context-shapes-overview.md
+++ b/guide/context-shapes-overview.md
@@ -43,9 +43,9 @@ __Telegraf passes every request to your middlewares as a `ctx` object, and each 
         apiRoot: 'https://api.telegram.org',
         apiMode: 'bot',
         webhookReply: boolean,
-        agent: [Agent],
-        attachmentAgent: undefined /* differs based on the configuration */,
-        testEnv: boolean
+        testEnv: boolean,
+        fetch: [Function],
+        requestTimeout: number
       }
     },
     botInfo: {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "Documentation and examples for Telegraf - the modern bot API framework",
 	"main": "echo.js",
 	"type": "module",
+	"packageManager": "pnpm@8.15.9",
 	"scripts": {
 		"build": "tsc"
 	},
@@ -17,7 +18,10 @@
 		"koa": "^2.14.1",
 		"koa-body": "^6.0.1",
 		"node-fetch": "^3.3.2",
-		"telegraf": "github:Leask/telegraf#bot-api-9.6-sync"
+		"telegraf": "git+https://github.com/Leask/telegraf.git#bot-api-9.6-sync"
+	},
+	"overrides": {
+		"@telegraf/types": "git+https://github.com/Leask/types.git#bot-api-9.6-sync"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.17",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
 		"https-proxy-agent": "^5.0.1",
 		"koa": "^2.14.1",
 		"koa-body": "^6.0.1",
-		"telegraf": "^4.14.0"
+		"node-fetch": "^3.3.2",
+		"telegraf": "github:Leask/telegraf#bot-api-9.6-sync"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.17",
 		"@types/koa": "^2.13.5",
-		"@types/node": "^18.14.6",
+		"@types/node": "^20.19.39",
 		"typescript": "^5.2.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"koa": "^2.14.1",
 		"koa-body": "^6.0.1",
 		"node-fetch": "^3.3.2",
-		"telegraf": "npm:@leask/telegraf@6.0.0"
+		"telegraf": "npm:@leask/telegraf@6.0.1"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.17",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,7 @@
 		"koa": "^2.14.1",
 		"koa-body": "^6.0.1",
 		"node-fetch": "^3.3.2",
-		"telegraf": "git+https://github.com/Leask/telegraf.git#bot-api-9.6-sync"
-	},
-	"overrides": {
-		"@telegraf/types": "git+https://github.com/Leask/types.git#bot-api-9.6-sync"
+		"telegraf": "npm:@leask/telegraf@6.0.0"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ dependencies:
     specifier: ^3.3.2
     version: 3.3.2
   telegraf:
-    specifier: github:Leask/telegraf#bot-api-9.6-sync
+    specifier: git+https://github.com/Leask/telegraf.git#bot-api-9.6-sync
     version: github.com/Leask/telegraf/07a9ef325efb1a53fb196de80ce8b817c1149b1e
 
 devDependencies:
@@ -1216,6 +1216,7 @@ packages:
     version: 6.0.0
     engines: {node: '>=20'}
     hasBin: true
+    prepare: true
     requiresBuild: true
     dependencies:
       '@telegraf/types': github.com/Leask/types/012947771d009d7ab1233dd96d95683d74471cf5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,12 @@ dependencies:
   koa-body:
     specifier: ^6.0.1
     version: 6.0.1
+  node-fetch:
+    specifier: ^3.3.2
+    version: 3.3.2
   telegraf:
-    specifier: ^4.14.0
-    version: 4.14.0
+    specifier: github:Leask/telegraf#bot-api-9.6-sync
+    version: github.com/Leask/telegraf/07a9ef325efb1a53fb196de80ce8b817c1149b1e
 
 devDependencies:
   '@types/express':
@@ -32,8 +35,8 @@ devDependencies:
     specifier: ^2.13.5
     version: 2.13.5
   '@types/node':
-    specifier: ^18.14.6
-    version: 18.18.0
+    specifier: ^20.19.39
+    version: 20.19.39
   typescript:
     specifier: ^5.2.2
     version: 5.2.2
@@ -60,10 +63,6 @@ packages:
     resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
     dependencies:
       fast-json-stringify: 5.8.0
-    dev: false
-
-  /@telegraf/types@6.9.1:
-    resolution: {integrity: sha512-bzqwhicZq401T0e09tu8b1KvGfJObPmzKU/iKCT5V466AsAZZWQrBYQ5edbmD1VZuHLEwopoOVY5wPP4HaLtug==}
     dev: false
 
   /@types/accepts@1.3.5:
@@ -156,6 +155,12 @@ packages:
 
   /@types/node@18.18.0:
     resolution: {integrity: sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==}
+
+  /@types/node@20.19.39:
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+    dependencies:
+      undici-types: 6.21.0
+    dev: true
 
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -348,6 +353,11 @@ packages:
       keygrip: 1.1.0
     dev: false
 
+  /data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+    dev: false
+
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -369,6 +379,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: false
+
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
     dev: false
 
   /deep-equal@1.0.1:
@@ -530,6 +552,14 @@ packages:
       reusify: 1.0.4
     dev: false
 
+  /fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+    dev: false
+
   /finalhandler@1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
     engines: {node: '>= 0.8'}
@@ -552,6 +582,13 @@ packages:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
       safe-regex2: 2.0.0
+    dev: false
+
+  /formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
     dev: false
 
   /formidable@2.0.1:
@@ -811,16 +848,19 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+    dev: false
+
+  /node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
-      whatwg-url: 5.0.0
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
     dev: false
 
   /object-inspect@1.12.2:
@@ -848,9 +888,9 @@ packages:
     resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==}
     dev: false
 
-  /p-timeout@4.1.0:
-    resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
-    engines: {node: '>=10'}
+  /p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
     dev: false
 
   /parseurl@1.3.3:
@@ -1088,24 +1128,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /telegraf@4.14.0:
-    resolution: {integrity: sha512-Nn2EBsuar/Mf3SD6O9tHmJ0FyJWnwAi4rewkJMmzd/O1xWYKglEuzSnCuHHRY7oD5NJ6WNPsavta5DbED8tG3w==}
-    engines: {node: ^12.20.0 || >=14.13.1}
-    hasBin: true
-    dependencies:
-      '@telegraf/types': 6.9.1
-      abort-controller: 3.0.0
-      debug: 4.3.4
-      mri: 1.2.0
-      node-fetch: 2.7.0
-      p-timeout: 4.1.0
-      safe-compare: 1.1.4
-      sandwich-stream: 2.0.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
   /thread-stream@2.0.1:
     resolution: {integrity: sha512-X7vWOdsHLkBq0si20ruEE2ttpS7WOVyD52xKu+TOjrRP9Qi9uB9ynHYpzZUbBptArBSuKYUn4mH+jEBnO2CRGg==}
     dependencies:
@@ -1120,10 +1142,6 @@ packages:
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-    dev: false
-
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: false
 
   /tsscmp@1.0.6:
@@ -1143,6 +1161,10 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
+
+  /undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
     dev: true
 
   /unpipe@1.0.0:
@@ -1166,15 +1188,9 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
-
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
+  /web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
     dev: false
 
   /wrappy@1.0.2:
@@ -1192,4 +1208,30 @@ packages:
 
   /zod@3.22.2:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
+    dev: false
+
+  github.com/Leask/telegraf/07a9ef325efb1a53fb196de80ce8b817c1149b1e:
+    resolution: {tarball: https://codeload.github.com/Leask/telegraf/tar.gz/07a9ef325efb1a53fb196de80ce8b817c1149b1e}
+    name: telegraf
+    version: 6.0.0
+    engines: {node: '>=20'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@telegraf/types': github.com/Leask/types/012947771d009d7ab1233dd96d95683d74471cf5
+      debug: 4.4.3
+      mri: 1.2.0
+      p-timeout: 7.0.1
+      safe-compare: 1.1.4
+      sandwich-stream: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  github.com/Leask/types/012947771d009d7ab1233dd96d95683d74471cf5:
+    resolution: {tarball: https://codeload.github.com/Leask/types/tar.gz/012947771d009d7ab1233dd96d95683d74471cf5}
+    name: '@telegraf/types'
+    version: 9.6.0
+    prepare: true
+    requiresBuild: true
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ dependencies:
     specifier: ^3.3.2
     version: 3.3.2
   telegraf:
-    specifier: git+https://github.com/Leask/telegraf.git#bot-api-9.6-sync
-    version: github.com/Leask/telegraf/07a9ef325efb1a53fb196de80ce8b817c1149b1e
+    specifier: npm:@leask/telegraf@6.0.0
+    version: /@leask/telegraf@6.0.0
 
 devDependencies:
   '@types/express':
@@ -63,6 +63,25 @@ packages:
     resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
     dependencies:
       fast-json-stringify: 5.8.0
+    dev: false
+
+  /@leask/telegraf@6.0.0:
+    resolution: {integrity: sha512-3scLSWBf1rJsEvBNvpSI0JfVLZfHzEDEFu8L4g/oRt8XCTiasf/4Bgi0C32+JbOV8Akdk5oe/xufAFG+fviqtw==}
+    engines: {node: '>=20'}
+    hasBin: true
+    dependencies:
+      '@telegraf/types': /@leask/types@9.6.0
+      debug: 4.4.3
+      mri: 1.2.0
+      p-timeout: 7.0.1
+      safe-compare: 1.1.4
+      sandwich-stream: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@leask/types@9.6.0:
+    resolution: {integrity: sha512-rCIH++ksNWJZ4JZ3j3aQ49xRDjMJlCTz64bQY4YzVunGgsI+jSBitXv751f2bz5Kqf2xgHlGCu+LXLvposGpYw==}
     dev: false
 
   /@types/accepts@1.3.5:
@@ -1208,31 +1227,4 @@ packages:
 
   /zod@3.22.2:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
-    dev: false
-
-  github.com/Leask/telegraf/07a9ef325efb1a53fb196de80ce8b817c1149b1e:
-    resolution: {tarball: https://codeload.github.com/Leask/telegraf/tar.gz/07a9ef325efb1a53fb196de80ce8b817c1149b1e}
-    name: telegraf
-    version: 6.0.0
-    engines: {node: '>=20'}
-    hasBin: true
-    prepare: true
-    requiresBuild: true
-    dependencies:
-      '@telegraf/types': github.com/Leask/types/012947771d009d7ab1233dd96d95683d74471cf5
-      debug: 4.4.3
-      mri: 1.2.0
-      p-timeout: 7.0.1
-      safe-compare: 1.1.4
-      sandwich-stream: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  github.com/Leask/types/012947771d009d7ab1233dd96d95683d74471cf5:
-    resolution: {tarball: https://codeload.github.com/Leask/types/tar.gz/012947771d009d7ab1233dd96d95683d74471cf5}
-    name: '@telegraf/types'
-    version: 9.6.0
-    prepare: true
-    requiresBuild: true
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ dependencies:
     specifier: ^3.3.2
     version: 3.3.2
   telegraf:
-    specifier: npm:@leask/telegraf@6.0.0
-    version: /@leask/telegraf@6.0.0
+    specifier: npm:@leask/telegraf@6.0.1
+    version: /@leask/telegraf@6.0.1
 
 devDependencies:
   '@types/express':
@@ -65,8 +65,8 @@ packages:
       fast-json-stringify: 5.8.0
     dev: false
 
-  /@leask/telegraf@6.0.0:
-    resolution: {integrity: sha512-3scLSWBf1rJsEvBNvpSI0JfVLZfHzEDEFu8L4g/oRt8XCTiasf/4Bgi0C32+JbOV8Akdk5oe/xufAFG+fviqtw==}
+  /@leask/telegraf@6.0.1:
+    resolution: {integrity: sha512-loLp4S/FbfRxzpw6leVJZwJUm06af2PXpMaV0+oJkCFuMlU2+h4jRlnmLIDsVJy2FO16E9IKqGl8DTXJfQDpkQ==}
     engines: {node: '>=20'}
     hasBin: true
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,11 @@
 	"compilerOptions": {
 		"strict": true,
 		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"target": "es2021",
-		"outDir": "./dist-examples"
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"skipLibCheck": true
 	},
 	"include": ["./global.d.ts", "./examples"],
 	"exclude": ["./examples/functions", "examples/mini-apps/serve"]


### PR DESCRIPTION
## Summary

This is the docs follow-up for Telegraf v6 and telegraf/telegraf#2092.

- documents the new native `globalThis.fetch` default and the removal of `telegram.agent` / `telegram.attachmentAgent`
- updates the proxy example to inject a custom `telegram.fetch` wrapper, which is used for both Bot API calls and URL attachments
- updates the context options shape to include `fetch` and `requestTimeout`
- refreshes examples that were stale against the v6 / Bot API 9.6 type surface (`thumbnail_url`, `correct_option_ids`, `telegraf/types`, webhook adapters)
- aligns the Fastify webhook example with Fastify body parsing by using the parsed request body with `bot.handleUpdate`
- aligns the AWS Lambda example with Telegraf v6 by using the Node.js 20 Lambda runtime and the v6 package shape
- switches the docs workspace and Lambda example to the published temporary npm alias `telegraf: npm:@leask/telegraf@6.0.1`
- declares the repo-level package manager as pnpm and documents the repo-level validation commands

## Stacking note

This PR is intentionally stacked on telegraf/telegraf#2092. Until Telegraf v6 and the matching `@telegraf/types` package are published upstream, the examples use the published temporary package alias `telegraf: npm:@leask/telegraf@6.0.1`; that package keeps Telegraf's public import name while depending on `@telegraf/types` via `npm:@leask/types@9.6.0`. This keeps the docs examples installable from npm packages only.

After the upstream v6 and types releases land, this should be switched back to the official published `telegraf@^6.0.0` dependency and the temporary alias can be removed.

## Forward path

The docs now describe the same future-facing infrastructure work as the v6 code branch: current Bot API type coverage, modern Node.js defaults, native fetch by default, custom fetch injection for advanced networking, and less legacy dependency surface for long-term maintenance.

## Validation

- `CI=true npx --yes pnpm@8.15.9 install --frozen-lockfile`
- `npx --yes pnpm@8.15.9 build`
- `cd examples/functions/aws-lambda && GIT_SSH_COMMAND=false npm ci && npx tsc --noEmit`
- registry alias migration verified in package manifests and lockfiles
- `git diff --check`
